### PR TITLE
Configure json formatter for log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It allows a number of configuration options to customize the logging to your nee
 
 ### Basic usage
 
-Simply add base component as your project's dependency and then one or more of three components discussed below to use it.
+Simply add base component as your project's dependency and then one or more of two components discussed below to use it.
 
 Base component dependency, gradle:
 ```groovy
@@ -58,15 +58,44 @@ log.info("An important business process has finished");
 
 ### Configuration defaults
 
-By default the module will use a simple, human-friendly logging format which can be used out-of-the-box for development:
+By default, the module will use json logging format which can be used out-of-the-box for development:
 
+Log format can be either set to `JSON` or `CONSOLE` by setting the environment variable `LOG_FORMAT`.
+
+JSON
+```
+{
+  "timestamp" : "2021-01-25T15:06:29.957+0000",
+  "level" : "INFO",
+  "thread" : "main",
+  "message" : "Request GET /some/path processed in 0ms",
+  "logger_name" : "app.quickcase.logging.filters.RequestStatusLoggingFilter"
+}{
+  "timestamp" : "2021-01-25T15:06:30.083+0000",
+  "level" : "ERROR",
+  "thread" : "main",
+  "message" : "Request GET /some/path failed in 0ms",
+  "exception" : "java.lang.RuntimeException: ..",
+  "logger_name" : "app.quickcase.logging.filters.RequestStatusLoggingFilter"
+}
+```
+
+CONSOLE
 ```
 2017-02-02 12:22:23,647 INFO [main] io.dropwizard.assets.AssetsBundle: Registering AssetBundle with name: swagger-assets for path /swagger-static/*
 2017-02-02 12:22:23,806 INFO [main] org.reflections.Reflections: Reflections took 96 ms to scan 1 urls, producing 79 keys and 87 values
 2017-02-02 12:22:24,835 INFO [main] io.dropwizard.server.DefaultServerFactory: Registering jersey handler with root path prefix: /
 ```
 
-Root logging level will be set to `INFO`. It can be adjusted by setting a `ROOT_LOGGING_LEVEL` environment variable.
+The default logging level will be set to `INFO`. It can be adjusted by setting the `LOG_LEVEL` environment variable.
+The following log levels are supported
+```
+ERROR
+WARN
+INFO
+DEBUG
+TRACE
+```
 
 ### Additional Logback configuration:
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ allprojects {
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
     implementation group: 'org.slf4j', name: 'jul-to-slf4j', version: '1.7.30'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    implementation group: 'ch.qos.logback.contrib', name: 'logback-jackson', version: '0.1.5'
+    implementation group: 'ch.qos.logback.contrib', name: 'logback-json-classic', version: '0.1.5'
     api group: 'javax.servlet', name: 'javax.servlet-api', version: '4.0.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
   }

--- a/java-logging-spring/src/test/resources/logback-test-receiver.xml
+++ b/java-logging-spring/src/test/resources/logback-test-receiver.xml
@@ -4,7 +4,7 @@
     <appender name="TEST_APPENDER" class="app.quickcase.logging.TestAppender"/>
 
     <root level="DEBUG">
-        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="JSON"/>
         <appender-ref ref="TEST_APPENDER"/>
     </root>
 

--- a/src/main/java/app/quickcase/logging/json/CustomJsonLayout.java
+++ b/src/main/java/app/quickcase/logging/json/CustomJsonLayout.java
@@ -1,0 +1,25 @@
+package app.quickcase.logging.json;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.contrib.json.classic.JsonLayout;
+
+import java.util.Map;
+
+public class CustomJsonLayout extends JsonLayout {
+
+    public static final String LOGGER_ATTR_NAME = "logger_name";
+
+    public CustomJsonLayout() {
+        super();
+        setIncludeMDC(false);
+        setIncludeContextName(false);
+        setIncludeLoggerName(false);
+    }
+
+    @Override
+    protected void addCustomDataToJsonMap(Map<String, Object> map, ILoggingEvent event) {
+        // Add custom logger attribute names
+        add(LOGGER_ATTR_NAME, true, event.getLoggerName(), map);
+    }
+
+}

--- a/src/main/resources/console-appender.xml
+++ b/src/main/resources/console-appender.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!--
-Console appender logback configuration
--->
-
+<!-- Console appender logback configuration -->
 <included>
-    <property name="LOGBACK_DATE_FORMAT" value="${LOGBACK_DATE_FORMAT:-yyyy-MM-dd'T'HH:mm:ss.SSS}"/>
+    <property name="LOGBACK_DATE_FORMAT" value="${LOGBACK_DATE_FORMAT:-yyyy-MM-dd'T'HH:mm:ss.SSS'Z'}"/>
     <property name="EXCEPTION_LENGTH" value="${EXCEPTION_LENGTH:-50}"/>
     <property name="LOGGER_LENGTH" value="${LOGGER_LENGTH:-50}"/>
     <property name="CONSOLE_LOG_PATTERN"
-              value="${CONSOLE_LOG_PATTERN:-%d{${LOGBACK_DATE_FORMAT}} %-5level [%thread] %logger{${LOGGER_LENGTH}}%ex{${EXCEPTION_LENGTH}} %msg%n}"/>
+              value="${CONSOLE_LOG_PATTERN:-%d{${LOGBACK_DATE_FORMAT}} %-5level [%thread] %logger{${LOGGER_LENGTH}} %ex{${EXCEPTION_LENGTH}}%msg%n}"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -19,7 +15,15 @@ Console appender logback configuration
     <appender name="ASYNC_CONSOLE" class="net.logstash.logback.appender.LoggingEventAsyncDisruptorAppender">
         <appender-ref ref="CONSOLE"/>
     </appender>
-
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="app.quickcase.logging.json.CustomJsonLayout">
+                <jsonFormatter
+                    class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter">
+                    <prettyPrint>true</prettyPrint>
+                </jsonFormatter>
+                <timestampFormat>${LOGBACK_DATE_FORMAT}</timestampFormat>
+            </layout>
+        </encoder>
+    </appender>
 </included>
-
-

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,8 +2,8 @@
 <configuration debug="${LOGBACK_CONFIGURATION_DEBUG:-false}">
    <include resource="logback-base.xml"/>
 
-    <root level="${ROOT_LOGGING_LEVEL:-INFO}">
-        <appender-ref ref="${ROOT_APPENDER:-ASYNC_CONSOLE}"/>
+    <root level="${LOG_LEVEL:-INFO}">
+        <appender-ref ref="${LOG_FORMAT:-JSON}"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
- Make json as the default format for log output
- Add custom json layout to control json logger attributes
